### PR TITLE
Implement stuck addon on cluster-1

### DIFF
--- a/platform/addons/charts/addon-atascado/Chart.yaml
+++ b/platform/addons/charts/addon-atascado/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: addon-atascado
+description: A Helm chart that deploys a ConfigMap and a Job that never completes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/platform/addons/charts/addon-atascado/README.md
+++ b/platform/addons/charts/addon-atascado/README.md
@@ -1,0 +1,60 @@
+# addon-atascado
+
+A simple Helm chart that demonstrates how an ArgoCD application can get stuck in the "Progressing" state.
+
+## Purpose
+
+This chart is designed for ArgoCD conference demonstrations to show how applications can get stuck in the synchronization process when resources like Jobs don't complete.
+
+## Components
+
+1. **ConfigMap**: A simple ConfigMap with a message about the demo
+
+2. **Job with conditional behavior**: The key component that will cause ArgoCD to stay in the "Progressing" state, but only in specific conditions:
+   - Uses a busybox container
+   - Checks if the two magic words (`magicWord1` and `magicWord2`) match
+   - If magic words match, it enters an infinite loop and never completes
+   - If magic words don't match, it completes normally
+   - Has backoffLimit set to 0 to prevent retries
+
+## How it works
+
+When ArgoCD deploys this chart:
+1. The ConfigMap is created successfully
+2. The Job checks if magic words match:
+   - If `magicWord1` and `magicWord2` have the same non-empty value, the Job will never complete, causing ArgoCD to stay in "Progressing" state
+   - If the magic words don't match, the Job completes normally, allowing ArgoCD to reach "Synced" state
+
+## Configuration
+
+You can configure the chart behavior with the following values:
+
+```yaml
+# values.yaml
+# Magic words that will cause the job to get stuck if they match
+magicWord1: "abracadabra"
+magicWord2: "hocus-pocus"
+```
+
+## Usage in Demo
+
+To use this chart in your ArgoCD conference demo:
+
+### Using magic words to trigger stuck state
+1. Create an ArgoCD Application with `magicWord1` and `magicWord2` set to the same value
+2. Show how the application gets stuck in "Progressing"
+3. Create another ArgoCD Application with different values for `magicWord1` and `magicWord2`
+4. Show how this application completes successfully
+
+### Demo Explanation
+5. Explain how Jobs and other resources that have completion criteria can affect ArgoCD sync status
+6. Demonstrate troubleshooting approaches for applications stuck in this state
+
+## Cleanup
+
+When you're done with the demo, you can manually delete the job:
+```
+kubectl delete job atascado-job
+```
+
+Or delete the entire ArgoCD application.

--- a/platform/addons/charts/addon-atascado/templates/NOTES.txt
+++ b/platform/addons/charts/addon-atascado/templates/NOTES.txt
@@ -1,0 +1,35 @@
+Thank you for installing {{ .Chart.Name }}.
+
+This chart has deployed:
+1. A ConfigMap named "{{ .Values.configMap.name }}"
+2. A Job named "{{ .Values.job.name }}" with conditional behavior
+
+Current configuration:
+- Current namespace: {{ .Release.Namespace }}
+- Magic Word 1: {{ .Values.magicWord1 }}
+- Magic Word 2: {{ .Values.magicWord2 }}
+
+Job behavior:
+{{- if eq .Values.magicWord1 .Values.magicWord2 }}
+{{- if ne .Values.magicWord1 "" }}
+- Magic words match! ({{ .Values.magicWord1 }})
+- The job will NEVER complete
+- ArgoCD will stay in "Progressing" state
+{{- else }}
+- Magic words match but are empty, job will complete normally
+- ArgoCD should reach "Synced" state
+{{- end }}
+{{- else }}
+- Magic words don't match
+- The job will complete normally
+- ArgoCD should reach "Synced" state
+{{- end }}
+
+To check the status of the job:
+  kubectl get jobs {{ .Values.job.name }} -n {{ .Release.Namespace }}
+
+To see the job logs:
+  kubectl logs job/{{ .Values.job.name }} -n {{ .Release.Namespace }}
+
+To manually delete the job when you're done with the demo:
+  kubectl delete job {{ .Values.job.name }} -n {{ .Release.Namespace }}

--- a/platform/addons/charts/addon-atascado/templates/configmap.yaml
+++ b/platform/addons/charts/addon-atascado/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configMap.name }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  message: {{ .Values.configMap.data.message | quote }}

--- a/platform/addons/charts/addon-atascado/templates/job.yaml
+++ b/platform/addons/charts/addon-atascado/templates/job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.job.name }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  # We don't set completions or activeDeadlineSeconds to ensure the job never completes when magic words match
+  backoffLimit: 0  # Don't retry on failure
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: atascado
+        image: {{ .Values.job.image }}
+        command: 
+          - "sh"
+          - "-c"
+          - |
+            CURRENT_NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+            echo "Current namespace: $CURRENT_NAMESPACE"
+            echo "Magic Word 1: {{ .Values.magicWord1 }}"
+            echo "Magic Word 2: {{ .Values.magicWord2 }}"
+            
+            # Check if the magic words match
+            if [ "{{ .Values.magicWord1 }}" = "{{ .Values.magicWord2 }}" ] && [ "{{ .Values.magicWord1 }}" != "" ]; then
+              echo "Magic words match! This job will never complete."
+              while true; do 
+                echo "Still running in stuck mode due to matching magic words..."
+                sleep 60
+              done
+            else
+              echo "Magic words don't match. This job will complete normally."
+              echo "Job completed successfully!"
+              exit 0
+            fi

--- a/platform/addons/charts/addon-atascado/test-chart.sh
+++ b/platform/addons/charts/addon-atascado/test-chart.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Testing addon-atascado Helm chart${NC}"
+echo -e "${YELLOW}=================================${NC}"
+
+# Create test namespace
+TEST_NS="atascado-test"
+echo -e "\n${GREEN}Creating test namespace: $TEST_NS${NC}"
+kubectl create namespace $TEST_NS 2>/dev/null || true
+
+# Test 1: Non-matching magic words (should complete)
+echo -e "\n${GREEN}Test 1: Non-matching magic words (should complete)${NC}"
+echo "Installing chart with magicWord1=abracadabra, magicWord2=hocus-pocus"
+helm upgrade --install atascado-test1 . \
+  --namespace $TEST_NS \
+  --set magicWord1=abracadabra \
+  --set magicWord2=hocus-pocus \
+  --wait --timeout 60s || echo -e "${RED}Timeout waiting for release to complete (expected to succeed)${NC}"
+
+echo -e "\n${GREEN}Checking job status:${NC}"
+kubectl get jobs -n $TEST_NS atascado-job
+echo -e "\n${GREEN}Job logs:${NC}"
+kubectl logs job/atascado-job -n $TEST_NS
+
+# Clean up first test
+echo -e "\n${GREEN}Cleaning up first test${NC}"
+helm uninstall atascado-test1 -n $TEST_NS
+kubectl delete job atascado-job -n $TEST_NS --ignore-not-found
+
+# Test 2: Matching magic words (should get stuck)
+echo -e "\n${GREEN}Test 2: Matching magic words (should get stuck)${NC}"
+echo "Installing chart with magicWord1=abracadabra, magicWord2=abracadabra"
+helm upgrade --install atascado-test2 . \
+  --namespace $TEST_NS \
+  --set magicWord1=abracadabra \
+  --set magicWord2=abracadabra \
+  --wait --timeout 30s || echo -e "${YELLOW}Timeout waiting for release to complete (expected behavior for stuck job)${NC}"
+
+echo -e "\n${GREEN}Checking job status:${NC}"
+kubectl get jobs -n $TEST_NS atascado-job
+echo -e "\n${GREEN}Job logs:${NC}"
+kubectl logs job/atascado-job -n $TEST_NS
+
+# Don't clean up second test automatically so user can inspect
+echo -e "\n${GREEN}Test complete!${NC}"
+echo -e "${YELLOW}The second test job is still running. To clean up:${NC}"
+echo "kubectl delete job atascado-job -n $TEST_NS"
+echo "helm uninstall atascado-test2 -n $TEST_NS"
+echo "kubectl delete namespace $TEST_NS"

--- a/platform/addons/charts/addon-atascado/values.yaml
+++ b/platform/addons/charts/addon-atascado/values.yaml
@@ -1,0 +1,16 @@
+# Default values for addon-atascado
+# This is a YAML-formatted file.
+
+# Magic words that will cause the job to get stuck if they match
+magicWord1: "cluster-1"
+magicWord2: "hocus-pocus"
+
+configMap:
+  name: atascado-config
+  data:
+    message: "This is a demo for ArgoCD stuck in progressing state"
+
+job:
+  name: atascado-job
+  image: busybox:latest
+  # Command will be constructed in the template based on magic words

--- a/platform/addons/charts/application-sets/templates/application-set.yaml
+++ b/platform/addons/charts/application-sets/templates/application-set.yaml
@@ -115,6 +115,10 @@ spec:
         environment: '{{`{{.metadata.labels.environment}}`}}'
         clusterName: '{{`{{.name}}`}}'
         kubernetesVersion: '{{`{{default "v1.32.0" (index .metadata.labels "kubernetesVersion")}}`}}'
+      {{- if $chartConfig.annotationsApp }}
+      annotations:
+        {{- toYaml $chartConfig.annotationsApp | nindent 8 }}
+      {{- end }}
     spec:
       project: default
       sources:

--- a/platform/addons/charts/kind-config.yaml
+++ b/platform/addons/charts/kind-config.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: argocd-demo
+nodes:
+- role: control-plane
+- role: worker

--- a/platform/addons/clusters/fleet/atascado.yaml
+++ b/platform/addons/clusters/fleet/atascado.yaml
@@ -4,34 +4,9 @@ atascado:
   namespace: atascado
   path: addons/charts/addon-atascado
   valuesObject:
-    stuckNamespace: cluster-1
     magicWord2: '{{.metadata.labels.clusterName}}'
   annotationsApp:
     argocd.argoproj.io/compare-options: ServerSideDiff=true
-  defaultVersion: "v1.15.1"
-  environments:
-  - selector:
-      environment: ci
-    chartVersion: "v1.17.1"
-  - selector:
-      environment: staging
-      maintenanceGroup: a
-    chartVersion: "v1.16.4"
-  - selector:
-      environment: staging
-      maintenanceGroup: b
-    chartVersion: "v1.16.3"
-  - selector:
-      environment: production
-      maintenanceGroup: canary
-    chartVersion: "v1.15.5"
-  - selector:
-      environment: production
-      maintenanceGroup: a
-    chartVersion: "v1.15.4"
-  - selector:
-      environment: production
-      maintenanceGroup: b
-    chartVersion: "v1.15.3"
+
 
 

--- a/platform/addons/clusters/fleet/atascado.yaml
+++ b/platform/addons/clusters/fleet/atascado.yaml
@@ -1,0 +1,37 @@
+atascado:
+  enabled: true
+  releaseName: atascado
+  namespace: atascado
+  path: addons/charts/addon-atascado
+  valuesObject:
+    stuckNamespace: cluster-1
+    magicWord2: '{{.metadata.labels.clusterName}}'
+  annotationsApp:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
+  defaultVersion: "v1.15.1"
+  environments:
+  - selector:
+      environment: ci
+    chartVersion: "v1.17.1"
+  - selector:
+      environment: staging
+      maintenanceGroup: a
+    chartVersion: "v1.16.4"
+  - selector:
+      environment: staging
+      maintenanceGroup: b
+    chartVersion: "v1.16.3"
+  - selector:
+      environment: production
+      maintenanceGroup: canary
+    chartVersion: "v1.15.5"
+  - selector:
+      environment: production
+      maintenanceGroup: a
+    chartVersion: "v1.15.4"
+  - selector:
+      environment: production
+      maintenanceGroup: b
+    chartVersion: "v1.15.3"
+
+

--- a/platform/fleet-management.yaml
+++ b/platform/fleet-management.yaml
@@ -24,3 +24,4 @@ spec:
       - $values/addons/clusters/fleet/common.yaml
       - $values/addons/clusters/fleet/cert-manager.yaml
       - $values/addons/clusters/fleet/metrics-server.yaml
+      - $values/addons/clusters/fleet/atascado.yaml


### PR DESCRIPTION
Added a new addon `atascado` it only gets stuck on `cluster-1` to make it stuck on a different cluster update the values.yaml inside the helm chart atascado replace `cluster-1` value with some other cluster like `cluster-3`